### PR TITLE
유저 생성시 동작 수정

### DIFF
--- a/src/db/users.js
+++ b/src/db/users.js
@@ -96,15 +96,15 @@ const localProfileSchema = Joi.object({
 const schemas = {
     google: baseSchema.concat(profileSchema).keys({
         google: googleProfileSchema,
-        stats: userStatsSchema
+        stats: userStatsSchema.default()
     }),
     local: baseSchema.concat(profileSchema).concat(localProfileSchema).keys({
-        stats: userStatsSchema
+        stats: userStatsSchema.default()
     })
 };
- 
+
 const users = db.get('users');
-    
+
 function getAll() {
     return users.find();
 }


### PR DESCRIPTION
- 유저 생성시 stats필드도 초기화하도록 변경했습니다.
- 적용하려면 db 리셋 필요합니다.
  - 리셋 방법: NODE_ENV=development npm run watch 로 서버 실행 후 /routes/dev/user/reset에 GET 요청
